### PR TITLE
Add usage section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,25 @@ Static web publishing using S3. Like [surge][], but without the syrup.
 
 [surge]: http://surge.sh/
 
+Usage
+--------
+Usage: `urj [options] <source> <target>`
+
+```
+args:
+
+   source: LocalPath
+   target: S3Uri
+ 
+Options:
+
+   -h, --help        output usage information
+   -V, --version     output the version number
+   -n, --no-clobber  Do not overwrite any existing release
+```
+
+Example: `urj mydirectory s3://mys3bucket`
+
 
 Features
 --------


### PR DESCRIPTION
The `s3://` prefix required by target wasn't immediately clear to me. Had to use external s3 docs for an example of a S3Uri, following error message:
```
Expected s3Uri, but got 'mys3bucket'
for the `dstPath` argument of the call.
```